### PR TITLE
Fixes #2 ExpirationDateString localization

### DIFF
--- a/CertCheck/ProductionServerCertificates.cs
+++ b/CertCheck/ProductionServerCertificates.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Net;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
@@ -15,14 +16,17 @@ namespace CertCheck
         {
             HttpWebRequest request = WebRequest.CreateHttp($"https://{domain}");
             request.ServerCertificateValidationCallback += ServerCertificateValidationCallback;
-            using (HttpWebResponse response = (HttpWebResponse)request.GetResponse()) {
+            using (HttpWebResponse response = (HttpWebResponse)request.GetResponse())
+            {
             }
-
         }
 
         private static bool ServerCertificateValidationCallback(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)
         {
-            var expirationDate = DateTime.Parse(certificate.GetExpirationDateString());
+            //see: https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.x509certificate.getexpirationdatestring?view=netcore-3.1#remarks
+            //Make sure we parse the DateTime.Parse(expirationdate) the same as GetExpirationDateString() does.
+            CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+            var expirationDate = DateTime.Parse(certificate.GetExpirationDateString(), CultureInfo.InvariantCulture);
             if (expirationDate - DateTime.Today < TimeSpan.FromDays(30))
             {
                 throw new Exception("Time to renew the certificate!");


### PR DESCRIPTION
GetExpirationDateString is dependant on culture setting, this forces datetime and certificate to have the same culturesetting.

As requested by @ardalis 